### PR TITLE
Update ToolContext documentation and API

### DIFF
--- a/docs/ref/tool_context.md
+++ b/docs/ref/tool_context.md
@@ -1,0 +1,3 @@
+# `Tool context`
+
+::: agents.tool_context

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -180,7 +180,7 @@ Sometimes, you don't want to use a Python function as a tool. You can directly c
 -   `name`
 -   `description`
 -   `params_json_schema`, which is the JSON schema for the arguments
--   `on_invoke_tool`, which is an async function that receives the context and the arguments as a JSON string, and must return the tool output as a string.
+-   `on_invoke_tool`, which is an async function that receives a [`ToolContext`][agents.tool_context.ToolContext] and the arguments as a JSON string, and must return the tool output as a string.
 
 ```python
 from typing import Any
@@ -211,23 +211,6 @@ tool = FunctionTool(
     params_json_schema=FunctionArgs.model_json_schema(),
     on_invoke_tool=run_function,
 )
-```
-
-### Tool context
-
-When `on_invoke_tool` is called, it receives a `ToolContext` instance. The object contains:
-
-- `context` – the context object you passed to `Runner.run()`.
-- `usage` – usage information for the run so far.
-- `tool_name` – the name of the tool being invoked.
-- `tool_call_id` – the ID of the tool call.
-
-You can access these fields inside your tool function:
-
-```python
-async def run_function(ctx: ToolContext[Any], args: str) -> str:
-    print("Tool invoked:", ctx.tool_name)
-    ...
 ```
 
 ### Automatic argument and docstring parsing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ plugins:
                     - ref/lifecycle.md
                     - ref/items.md
                     - ref/run_context.md
+                    - ref/tool_context.md
                     - ref/usage.md
                     - ref/exceptions.md
                     - ref/guardrail.md

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -549,7 +549,9 @@ class RunImpl:
         ) -> Any:
             with function_span(func_tool.name) as span_fn:
                 tool_context = ToolContext.from_agent_context(
-                    context_wrapper, func_tool.name, tool_call.call_id
+                    context_wrapper,
+                    tool_call.call_id,
+                    tool_call=tool_call,
                 )
                 if config.trace_include_sensitive_data:
                     span_fn.span_data.input = tool_call.arguments

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, fields
 from typing import Any
 
+from openai.types.responses import ResponseFunctionToolCall
+
 from .run_context import RunContextWrapper, TContext
 
 
@@ -24,7 +26,10 @@ class ToolContext(RunContextWrapper[TContext]):
 
     @classmethod
     def from_agent_context(
-        cls, context: RunContextWrapper[TContext], tool_name: str, tool_call_id: str
+        cls,
+        context: RunContextWrapper[TContext],
+        tool_call_id: str,
+        tool_call: ResponseFunctionToolCall | None = None,
     ) -> "ToolContext":
         """
         Create a ToolContext from a RunContextWrapper.
@@ -33,4 +38,5 @@ class ToolContext(RunContextWrapper[TContext]):
         base_values: dict[str, Any] = {
             f.name: getattr(context, f.name) for f in fields(RunContextWrapper) if f.init
         }
+        tool_name = tool_call.name if tool_call is not None else _assert_must_pass_tool_name()
         return cls(tool_name=tool_name, tool_call_id=tool_call_id, **base_values)


### PR DESCRIPTION
## Summary
- add `ref/tool_context.md` with mkdocstrings directive
- link to `ToolContext` in tools document and drop redundant section
- update mkdocs.yml navigation
- adjust `ToolContext.from_agent_context` signature
- update `_run_impl` to pass tool call object

## Testing
- `make format`
- `make lint`
- `make mypy`
- `OPENAI_API_KEY=sk-dummy make tests`
- `CI=1 make build-docs`

------
https://chatgpt.com/codex/tasks/task_e_686f4e819930832da1a7650e8da86538